### PR TITLE
fix: interrupt error

### DIFF
--- a/threads/thread.c
+++ b/threads/thread.c
@@ -713,7 +713,9 @@ void preemption(void)
 		!list_empty(&ready_list) 
 		&& thread_current()->priority < list_entry(list_front(&ready_list), struct thread, elem)->priority
 	) {
-        thread_yield();
+		if (!intr_context ()) {
+			thread_yield();
+		}
 	}
 }
 


### PR DESCRIPTION
- userprog에서 make check 시 에러 발생
- preemption에서 intr_context 체크 로직 추가
- 인터럽트 상황이 아닐 때에만 실행되도록 수정